### PR TITLE
091221 - Disable draft until next year

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -58,7 +58,7 @@ owners:
   - Jordan Holland
   - Nathan Lee
   - Patrick Cooper
-draft_enabled: True
+draft_enabled: False
 sql_flavor: postgres
 num_teams: 32
 espn_url: https://www.espn.com/nfl/standings/_/season/2021


### PR DESCRIPTION
Disable draft functionality so the bot doesn't respond to any `draft` messages